### PR TITLE
Issue #1 - Switch to a stylesheet for hiding extension in about:addons

### DIFF
--- a/cck2/modules/CCK2AboutAddonsOverlay.jsm
+++ b/cck2/modules/CCK2AboutAddonsOverlay.jsm
@@ -27,10 +27,13 @@ var observer = {
               for (id in configs) {
                 var config = configs[id];
                 if (config && "extension" in config && config.extension.hide) {
-                  win.addEventListener("ViewChanged", function() {
-                    hide(doc.querySelector("richlistitem[value='" + config.extension.id + "']"));
-                  } , false)
-                  hide(doc.querySelector("richlistitem[value='" + config.extension.id + "']"));
+                  for (var i = 0; i < doc.styleSheets.length; i++) {
+                    if (doc.styleSheets[i].href == "chrome://mozapps/skin/extensions/extensions.css") {
+                      var ss = doc.styleSheets[i];
+                      ss.insertRule("richlistitem[value='" + config.extension.id + "'] { display: none;}", ss.cssRules.length);
+                      break;
+                    }
+                  }
                 }
               }
               var showDiscoverPane = true;


### PR DESCRIPTION
My old method of explicitly hiding the richlistitem on ViewChanged was fragile especially as you switched back and forth.

This version adds a stylesheet rule that explicitly hides it, so it should never show up (although there is a flash at the beginning).

Fixes Issues #1.