### PR TITLE
Issues #3 - If Hello is disabled, hide Start Conversation menu

### DIFF
--- a/cck2/modules/CCK2BrowserOverlay.jsm
+++ b/cck2/modules/CCK2BrowserOverlay.jsm
@@ -99,6 +99,7 @@ var observer = {
                   }
                   if (config.disableHello) {
                     CustomizableUI.destroyWidget("loop-button");
+                    hide(E("menu_openLoop", doc));
                   }
                   if (config.disablePocket) {
                     CustomizableUI.destroyWidget("pocket-button");


### PR DESCRIPTION
Hide Hello menu if hello is diabled.

Fixes #3 .