### PR TITLE
Issue #7 - Add support for removing all builtin search engines

### DIFF
--- a/cck2/modules/CCK2.jsm
+++ b/cck2/modules/CCK2.jsm
@@ -156,6 +156,10 @@ var CCK2 = {
       Preferences.lock("distribution.version", config.version + " (CCK2)");
 //      Preferences.lock("distribution.about", String(config.id + " - " + config.version + " (CCK2)"));
 
+      if (config.removeDefaultSearchEngines) {
+        Services.io.getProtocolHandler("resource").QueryInterface(Components.interfaces.nsIResProtocolHandler)
+                                                  .setSubstitution("search-plugins", null);
+      }
       if (config.noAddonCompatibilityCheck) {
         Preferences.reset("extensions.lastAppVersion");
       }

--- a/content/searchengines.xul
+++ b/content/searchengines.xul
@@ -37,6 +37,7 @@
          </menulist>
       </hbox>
       <checkbox config="disableSearchEngineInstall" label="&disableSearchEngineInstall.label;"/>
+      <checkbox config="removeDefaultSearchEngines" label="&removeDefaultSearchEngines.label;"/>
     </vbox>
   </deck>
       <popupset>

--- a/locale/en-US/searchengines.dtd
+++ b/locale/en-US/searchengines.dtd
@@ -10,3 +10,4 @@
 <!ENTITY defaultSearchEngine.label "Default Search Engine">
 <!ENTITY browserDefault.label "(don't change)">
 <!ENTITY disableSearchEngineInstall.label "Do not allow search engines to be installed from web pages">
+<!ENTITY removeDefaultSearchEngines.label "Remove all default search engines">


### PR DESCRIPTION
Simple patch to remove the search-plugins resource effectively breaking all built in search plugins. If you do this, you need to add your own engines.