### PR TITLE
Issues #8 - Add deprecation message for server certs and try/catch

### DIFF
--- a/cck2/modules/CCK2.jsm
+++ b/cck2/modules/CCK2.jsm
@@ -835,7 +835,11 @@ var CCK2 = {
               for (var i=0; i < config.certs.server.length; i++) {
                 try {
                   download(config.certs.server[i], function(file) {
-                    certdb.importCertsFromFile(null, file, Ci.nsIX509Cert.SERVER_CERT);
+                    try {
+                      certdb.importCertsFromFile(null, file, Ci.nsIX509Cert.SERVER_CERT);
+                    } catch(e) {
+                      // API removed in bugzilla #1064402 (FF47)
+                    }
                   }, errorCritical);
                 } catch (e) {
                   errorCritical("Unable to install " + config.certs.server[i] + " - " + e);

--- a/content/certificates.xul
+++ b/content/certificates.xul
@@ -30,6 +30,7 @@
             </hbox>
           </tabpanel>
           <tabpanel orient="vertical">
+            <label href="https://bugzilla.mozilla.org/show_bug.cgi?id=1064402" style="font-weight: bold" class="text-link cck2wizard-description">&serverCertificates.description2;</label>
             <description class="cck2wizard-description">&serverCertificates.description;</description>
             <listbox id="servercerts-listbox" context="servercerts-listbox-contextmenu" onkeypress="onKeyPressCertificate(event);" flex="1" />
             <hbox>

--- a/locale/en-US/certificates.dtd
+++ b/locale/en-US/certificates.dtd
@@ -19,6 +19,7 @@
 
 <!ENTITY certificateAuthorties.description "Certificates that identify certificate authorities">
 <!ENTITY serverCertificates.description "Certificates that identify servers">
+<!ENTITY serverCertificates.description2 "Server certificates are being removed. Click for more information.">
 <!ENTITY certificateOverrides.description "Domains for which self-signed certificates are allowed">
 <!ENTITY devices.description "Security Devices">
 


### PR DESCRIPTION
Instead of removing server tab completely, add warning and add try/catch around call.