### PR TITLE
Revert "Switch to new API for addon installs"

### DIFF
--- a/cck2/modules/CCK2.jsm
+++ b/cck2/modules/CCK2.jsm
@@ -932,7 +932,8 @@ var CCK2 = {
             var numAddonsInstalled = 0;
             var numAddons = config.addons.length;
             for (var i=0; i < config.addons.length; i++) {
-              AddonManager.getInstallForURL(config.addons[i], "application/x-xpinstall").then(addonInstall => {
+              try {
+              AddonManager.getInstallForURL(config.addons[i], function(addonInstall) {
                 let listener = {
                   onInstallEnded: function(install, addon) {
                     if (addon.isActive) {
@@ -946,10 +947,13 @@ var CCK2 = {
                       Services.startup.quit(Services.startup.eRestart | Services.startup.eAttemptQuit);
                     }
                   }
-                };
+                }
                 addonInstall.addListener(listener);
                 addonInstall.install();
-              });
+              }, "application/x-xpinstall");
+              } catch (e) {
+                errorCritical(e);
+              }
             }
           }
         }


### PR DESCRIPTION
Reverts mkaply/cck2wizard#92

This was a dumb change. Fixes 63 but breaks older builds.